### PR TITLE
makes asdev a cargo plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ description = "a-s-dev"
 [dependencies]
 dialoguer = "0.5.0"
 clap = "2.33"
+
+[[bin]]
+name = "cargo-asdev"
+path = "src/main.rs"

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,19 +92,25 @@ const COMMANDS: &[(&str, (&str, &str))] = &[
 fn main() {
     let map: HashMap<&str, (&str, &str)> = COMMANDS.iter().cloned().collect();
     let matches = App::new(env!("CARGO_PKG_NAME"))
-        .about("Helps you navigate the Application Services repository")
-        .author("Application Services Team")
-        .version(env!("CARGO_PKG_VERSION"))
-        .subcommands(
-            COMMANDS
-                .iter()
-                .map(|(key_word, (title, _cmd))| SubCommand::with_name(key_word).about(*title)),
+        .bin_name("cargo")
+        .subcommand(
+            SubCommand::with_name("asdev")
+                .about("Helps you navigate the Application Services repository")
+                .author("Application Services Team")
+                .version(env!("CARGO_PKG_VERSION"))
+                .subcommands(COMMANDS.iter().map(|(key_word, (title, _cmd))| {
+                    SubCommand::with_name(key_word).about(*title)
+                })),
         )
         .get_matches();
 
-    match map.get(matches.subcommand().0) {
-        Some(val) => spawn(val.1),
-        None => run_default(),
+    if let Some(matches) = matches.subcommand_matches("asdev") {
+        match map.get(matches.subcommand().0) {
+            Some(val) => spawn(val.1),
+            None => run_default(),
+        }
+    } else {
+        run_default()
     }
 }
 


### PR DESCRIPTION
Allow asdev to be run as a cargo plugin, i.e: `cargo asdev` can be used to run it.

This allows it to be used for aliasing in the a-s repository. 